### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,31 @@
 
 - No external dependencies more than few [Go's stdlib](https://golang.org/pkg/#stdlib) ones.
 - Compact but concise API.
-- Global and command flags support.
+- Global flags support.
+- Single-level commands support only.
 - `bool`, `int`, `string` and `[]string` flag's data types.
 - Flag aliases and default values support.
+- Optional environment variable names for flags.
 - Convenient contexts for function handlers (global and command flags)
 - Context built-in types conversion API for `bool`, `int`, `string` and `[]string` flag values.
-- Convenient API to detect provided (passed) flags only with thier props.
-- Optional environment variable names for flags.
+- Convenient API to detect provided (passed) flags with thier properties.
+- Strict UTF-8 for arguments and alphanumeric ASCII for flags and commands.
+- POSIX-compliant support is intentionally partial (see the limitations below).
+- Support for flags termination via `--` to provide further positional arguments (tail args).
+- Same repeated flag arguments use the last value provided.
 - Automatic `--help` (`-h`) flag for global flags and commands.
-- Automatic `--version` (`-v`) flag with relevant info like app version, Go version, build datetime and OS/Arch.
+- Automatic `--version` (`-v`) flag with relevant information like app version, Go version, build datetime and OS/Arch and commit.
 
-### Work in progress
+## Limitations
 
-- POSIX-compliant flags support is partial. Please see [issue #3](https://github.com/joseluisq/cline/issues/3)
-- Subcommands are not supported yet.
+The following POSIX features are intentionally NOT supported:
+
+- Short single-dash combined flags (e.g. `-abc` for `-a -b -c`).
+- Short single-dash flags with equal sign (e.g. `-f=value` or `--file=value`).
+- Single hyphen to denote standard inpu or output (e.g. `myapp -`).
+- Optional whitespace between flags and their values (e.g. `-vfoo` for `-v foo`).
+
+Please see [issue #3](https://github.com/joseluisq/cline/issues/3) for details.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - Convenient API to detect provided (passed) flags with thier properties.
 - Strict UTF-8 for arguments and alphanumeric ASCII for flags and commands.
 - POSIX-compliant support is intentionally partial (see the limitations below).
+- Restrict the maximum argument length and maximum number of arguments provided.
 - Support for flags termination via `--` to provide further positional arguments (tail args).
 - Same repeated flag arguments use the last value provided.
 - Automatic `--help` (`-h`) flag for global flags and commands.
@@ -27,10 +28,10 @@ The following POSIX features are intentionally NOT supported:
 
 - Short single-dash combined flags (e.g. `-abc` for `-a -b -c`).
 - Short single-dash flags with equal sign (e.g. `-f=value` or `--file=value`).
-- Single hyphen to denote standard inpu or output (e.g. `myapp -`).
+- Single hyphen to denote standard input or output (e.g. `myapp -`).
 - Optional whitespace between flags and their values (e.g. `-vfoo` for `-v foo`).
 
-Please see [issue #3](https://github.com/joseluisq/cline/issues/3) for details.
+Please see [POSIX-compliant support (#3)](https://github.com/joseluisq/cline/issues/3) for details.
 
 ## Usage
 

--- a/app/app.go
+++ b/app/app.go
@@ -33,7 +33,7 @@ func New() *App {
 	return &App{}
 }
 
-// PrintVersion prints the current application version information (--version).
+// PrintVersion prints the current application version information (--version, -v).
 func (ap *App) PrintVersion() {
 	fmt.Printf("Version:       %s\n", ap.Version)
 	fmt.Printf("Go version:    %s\n", runtime.Version())

--- a/app/app_context.go
+++ b/app/app_context.go
@@ -11,6 +11,7 @@ type AppContext struct {
 	tailArgs []string
 }
 
+// NewContext creates a new application context.
 func NewContext(app *App, flagValues *flag.FlagValues, tailArgs []string) *AppContext {
 	return &AppContext{
 		app:      app,


### PR DESCRIPTION
This PR introduces the first major version `1.0.0`.

### Changelog

**Breaking change**

Although changes are expected to be minor, existing code needs to be updated.

- Golang 1.23 is required as a minimum.
- API is changed.
    - `App` type is decoupled from the `Handler` logic, resulting in a new `Handler` type.
    - Some structs are renamed like `Flag` types, `Flag` values, `Cmds` and helpers.

**Refactorings**

- Restructured modules (files and directories).
- Improved Tests and code coverage CI, as well as refactored a few APIs. The library requires Golang 1.23 or later.

**Improvements**

-  Strict UTF-8 for arguments and alphanumeric ASCII for flags and commands.
- POSIX-compliant support is partially supported (see [the limitations](https://github.com/joseluisq/cline?tab=readme-ov-file#limitations)).
- Support for flags termination via `--` to provide further positional arguments (tail args).
- Same repeated flag arguments use the last value provided.
- Option to restrict the maximum argument length and the maximum number of arguments provided.

**Fixes**

- Inconsistent use of aliases for special `version` and `help`)  flags like `--v` or `--h`.

For the usage of the new API, please check out the examples to adjust existing apps accordingly.
 the [./examples](https://github.com/joseluisq/cline/tree/master/examples) directory.

For more details, see the [v1.0.0 milestone](https://github.com/joseluisq/cline/milestone/1?closed=1) and the full changelog [v0.1.0...v1.0.0](https://github.com/static-web-server/static-web-server/compare/v0.1.0...v1.0.0).