### PR TITLE
Enable OS/Arch information in version option (`--version`)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -39,4 +39,5 @@ func (ap *App) PrintVersion() {
 	fmt.Printf("Go version:    %s\n", runtime.Version())
 	fmt.Printf("Built:         %s\n", ap.BuildTime)
 	fmt.Printf("Commit:        %s\n", ap.BuildCommit)
+	fmt.Printf("OS/Arch:       %s/%s\n", runtime.GOOS, runtime.GOARCH)
 }

--- a/print/print.go
+++ b/print/print.go
@@ -1,3 +1,4 @@
+// Package print provides functions to print application information to the console.
 package print
 
 import (


### PR DESCRIPTION
This PR enables the missing `OS/Arch` present before `v1.0.0`.

**Before**

```sh
$ enve --version
Version:       1.6.0
Go version:    go1.25.4 X:nodwarf5
Built:         2026-01-04T23:20:35Z
Commit:        bb609d6205272451ca1664c0ba1c985ce1dd1834
```

**After**

```sh
$ enve --version
Version:       devel
Go version:    go1.25.4 X:nodwarf5
Built:         2026-01-04T23:20:35Z
Commit:        c84b5a13d89ff71f4da4fd6b7179f05da5f296e7
OS/Arch:       linux/amd64
```
